### PR TITLE
Fix rpath on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ CFLAGS = $(XAV_DEBUG_LOGS) -fPIC -shared
 IFLAGS = -I$(ERTS_INCLUDE_DIR) -I$(XAV_DIR)
 LDFLAGS = -lavcodec -lswscale -lavutil -lavformat -lavdevice -lswresample
 
-# Falgs for MacOS
+# Flags for MacOS
 ifeq ($(shell uname -s),Darwin)
 	ifeq ($(shell uname -m),arm64)
 		IFLAGS += $$(pkg-config --cflags-only-I libavcodec libswscale libavutil libavformat libavdevice libswresample)


### PR DESCRIPTION
Hi thanks for the great library! 

I had this error when I was trying it in livebook:

```
==> xav
mkdir -p /Users/cocoa/Library/Caches/mix/installs/elixir-1.18.0-dev-erts-14.2.5/503bcf1cf3014730824ad3404eadbb09/_build/dev/lib/xav/priv
cc  -fPIC -shared -undefined dynamic_lookup -I/usr/local/lib/erlang/erts-14.2.5/include -Ic_src/xav $(pkg-config --cflags-only-I libavcodec libswscale libavutil libavformat libavdevice libswresample) $(pkg-config --libs-only-L libavcodec libswscale libavutil libavformat libavdevice libswresample) c_src/xav/xav_decoder.c c_src/xav/decoder.c c_src/xav/video_converter.c c_src/xav/audio_converter.c c_src/xav/utils.c -o /Users/cocoa/Library/Caches/mix/installs/elixir-1.18.0-dev-erts-14.2.5/503bcf1cf3014730824ad3404eadbb09/_build/dev/lib/xav/priv/libxavdecoder.so -lavcodec -lswscale -lavutil -lavformat -lavdevice -lswresample
mkdir -p /Users/cocoa/Library/Caches/mix/installs/elixir-1.18.0-dev-erts-14.2.5/503bcf1cf3014730824ad3404eadbb09/_build/dev/lib/xav/priv
cc  -fPIC -shared -undefined dynamic_lookup -I/usr/local/lib/erlang/erts-14.2.5/include -Ic_src/xav $(pkg-config --cflags-only-I libavcodec libswscale libavutil libavformat libavdevice libswresample) $(pkg-config --libs-only-L libavcodec libswscale libavutil libavformat libavdevice libswresample) c_src/xav/xav_reader.c c_src/xav/reader.c c_src/xav/video_converter.c c_src/xav/audio_converter.c c_src/xav/utils.c -o /Users/cocoa/Library/Caches/mix/installs/elixir-1.18.0-dev-erts-14.2.5/503bcf1cf3014730824ad3404eadbb09/_build/dev/lib/xav/priv/libxavreader.so -lavcodec -lswscale -lavutil -lavformat -lavdevice -lswresample
c_src/xav/xav_reader.c:118:1: warning: non-void function does not return a value in all control paths [-Wreturn-type]
}
^
1 warning generated.
Compiling 5 files (.ex)

11:39:27.014 [warning] The on_load function for module Elixir.Xav.Reader.NIF returned:
{{:badmatch,
  {:error,
   {:load_failed,
    ~c"Failed to load NIF library: 'dlopen(/Users/cocoa/Library/Caches/mix/installs/elixir-1.18.0-dev-erts-14.2.5/503bcf1cf3014730824ad3404eadbb09/_build/dev/lib/xav/priv/libxavreader.so, 0x0002): Library not loaded: @rpath/libavcodec.60.dylib\n  Referenced from: <985E3203-4F08-3CFF-9B2E-50B12E2945C0> /Users/cocoa/Library/Caches/mix/installs/elixir-1.18.0-dev-erts-14.2.5/503bcf1cf3014730824ad3404eadbb09/_build/dev/lib/xav/priv/libxavreader.so\n  Reason: no LC_RPATH's found'"}}},
 [
   {Xav.Reader.NIF, :__on_load__, 0, [file: ~c"lib/reader_nif.ex", line: 8]},
   {:code_server, :"-handle_on_load/5-fun-0-", 1,
    [file: ~c"code_server.erl", line: 1393]}
 ]}


11:39:27.007 [warning] The on_load function for module Elixir.Xav.Decoder.NIF returned:
{{:badmatch,
  {:error,
   {:load_failed,
    ~c"Failed to load NIF library: 'dlopen(/Users/cocoa/Library/Caches/mix/installs/elixir-1.18.0-dev-erts-14.2.5/503bcf1cf3014730824ad3404eadbb09/_build/dev/lib/xav/priv/libxavdecoder.so, 0x0002): Library not loaded: @rpath/libavcodec.60.dylib\n  Referenced from: <5AA6328F-60C5-3F07-A412-D0E14F369023> /Users/cocoa/Library/Caches/mix/installs/elixir-1.18.0-dev-erts-14.2.5/503bcf1cf3014730824ad3404eadbb09/_build/dev/lib/xav/priv/libxavdecoder.so\n  Reason: no LC_RPATH's found'"}}},
 [
   {Xav.Decoder.NIF, :__on_load__, 0, [file: ~c"lib/decoder_nif.ex", line: 8]},
   {:code_server, :"-handle_on_load/5-fun-0-", 1,
    [file: ~c"code_server.erl", line: 1393]}
 ]}


11:39:26.885 [error] Process #PID<0.1426.0> on node :"livebook_tc7nw5xd--ca5tycuk@127.0.0.1" raised an exception
** (MatchError) no match of right hand side value: {:error, {:load_failed, ~c"Failed to load NIF library: 'dlopen(/Users/cocoa/Library/Caches/mix/installs/elixir-1.18.0-dev-erts-14.2.5/503bcf1cf3014730824ad3404eadbb09/_build/dev/lib/xav/priv/libxavdecoder.so, 0x0002): Library not loaded: @rpath/libavcodec.60.dylib\n  Referenced from: <5AA6328F-60C5-3F07-A412-D0E14F369023> /Users/cocoa/Library/Caches/mix/installs/elixir-1.18.0-dev-erts-14.2.5/503bcf1cf3014730824ad3404eadbb09/_build/dev/lib/xav/priv/libxavdecoder.so\n  Reason: no LC_RPATH's found'"}}
    lib/decoder_nif.ex:8: Xav.Decoder.NIF.__on_load__/0
    (kernel 9.2.4) code_server.erl:1393: anonymous fn/1 in :code_server.handle_on_load/5

11:39:27.004 [error] Process #PID<0.1427.0> on node :"livebook_tc7nw5xd--ca5tycuk@127.0.0.1" raised an exception
** (MatchError) no match of right hand side value: {:error, {:load_failed, ~c"Failed to load NIF library: 'dlopen(/Users/cocoa/Library/Caches/mix/installs/elixir-1.18.0-dev-erts-14.2.5/503bcf1cf3014730824ad3404eadbb09/_build/dev/lib/xav/priv/libxavreader.so, 0x0002): Library not loaded: @rpath/libavcodec.60.dylib\n  Referenced from: <985E3203-4F08-3CFF-9B2E-50B12E2945C0> /Users/cocoa/Library/Caches/mix/installs/elixir-1.18.0-dev-erts-14.2.5/503bcf1cf3014730824ad3404eadbb09/_build/dev/lib/xav/priv/libxavreader.so\n  Reason: no LC_RPATH's found'"}}
    lib/reader_nif.ex:8: Xav.Reader.NIF.__on_load__/0
    (kernel 9.2.4) code_server.erl:1393: anonymous fn/1 in :code_server.handle_on_load/5
Generated xav app
```

And here is the output when running `otool` on the shared library

```
/Users/cocoa/Library/Caches/mix/installs/elixir-1.18.0-dev-erts-14.2.5/503bcf1cf3014730824ad3404eadbb09/_build/dev/lib/xav/priv/libxavreader.so:
	/Users/cocoa/Library/Caches/mix/installs/elixir-1.18.0-dev-erts-14.2.5/503bcf1cf3014730824ad3404eadbb09/_build/dev/lib/xav/priv/libxavreader.so (compatibility version 0.0.0, current version 0.0.0)
	@rpath/libavcodec.60.dylib (compatibility version 60.0.0, current version 60.0.0)
	@rpath/libswscale.7.dylib (compatibility version 7.0.0, current version 7.0.0)
	@rpath/libavutil.58.dylib (compatibility version 58.0.0, current version 58.0.0)
	@rpath/libavformat.60.dylib (compatibility version 60.0.0, current version 60.0.0)
	/opt/homebrew/opt/ffmpeg@4/lib/libavdevice.58.dylib (compatibility version 58.0.0, current version 58.13.100)
	@rpath/libswresample.4.dylib (compatibility version 4.0.0, current version 4.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1345.120.2)
```

As you can see, some libraries are referenced using `@rpath` while `libavdevice` is using the absolute path, and for some reason there's no `LC_RPATH` in the compiled binaries.

This PR should address this issue by parsing the results from `pkg-config` and adding each unique path (for the relevant libraries) to the binaries' RPATH.