### PR TITLE
raise `unknown_media_type`

### DIFF
--- a/c_src/xav/xav_reader.c
+++ b/c_src/xav/xav_reader.c
@@ -114,6 +114,8 @@ ERL_NIF_TERM new(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
     ERL_NIF_TERM out_format_term = enif_make_atom(env, "rgb");
     return enif_make_tuple(env, 7, ok_term, xav_term, in_format_term, out_format_term,
                            bit_rate_term, duration_term, codec_term);
+  } else {
+    return xav_nif_raise(env, "unknown_media_type");
   }
 }
 


### PR DESCRIPTION
This PR fixes this warning -- so we return a valid `ERL_NIF_TERM` for all control paths.

```
==> xav
mkdir -p /Users/cocoa/Library/Caches/mix/installs/elixir-1.18.0-dev-erts-14.2.5/503bcf1cf3014730824ad3404eadbb09/_build/dev/lib/xav/priv
cc  -fPIC -shared -undefined dynamic_lookup -I/usr/local/lib/erlang/erts-14.2.5/include -Ic_src/xav $(pkg-config --cflags-only-I libavcodec libswscale libavutil libavformat libavdevice libswresample) $(pkg-config --libs-only-L libavcodec libswscale libavutil libavformat libavdevice libswresample) c_src/xav/xav_decoder.c c_src/xav/decoder.c c_src/xav/video_converter.c c_src/xav/audio_converter.c c_src/xav/utils.c -o /Users/cocoa/Library/Caches/mix/installs/elixir-1.18.0-dev-erts-14.2.5/503bcf1cf3014730824ad3404eadbb09/_build/dev/lib/xav/priv/libxavdecoder.so -lavcodec -lswscale -lavutil -lavformat -lavdevice -lswresample
mkdir -p /Users/cocoa/Library/Caches/mix/installs/elixir-1.18.0-dev-erts-14.2.5/503bcf1cf3014730824ad3404eadbb09/_build/dev/lib/xav/priv
cc  -fPIC -shared -undefined dynamic_lookup -I/usr/local/lib/erlang/erts-14.2.5/include -Ic_src/xav $(pkg-config --cflags-only-I libavcodec libswscale libavutil libavformat libavdevice libswresample) $(pkg-config --libs-only-L libavcodec libswscale libavutil libavformat libavdevice libswresample) c_src/xav/xav_reader.c c_src/xav/reader.c c_src/xav/video_converter.c c_src/xav/audio_converter.c c_src/xav/utils.c -o /Users/cocoa/Library/Caches/mix/installs/elixir-1.18.0-dev-erts-14.2.5/503bcf1cf3014730824ad3404eadbb09/_build/dev/lib/xav/priv/libxavreader.so -lavcodec -lswscale -lavutil -lavformat -lavdevice -lswresample
c_src/xav/xav_reader.c:118:1: warning: non-void function does not return a value in all control paths [-Wreturn-type]
}
^
1 warning generated.
```