### PR TITLE
Make `nx` optional

### DIFF
--- a/lib/frame.ex
+++ b/lib/frame.ex
@@ -63,17 +63,19 @@ defmodule Xav.Frame do
     }
   end
 
-  @doc """
-  Converts a frame to an Nx tensor.
-  """
-  @spec to_nx(t()) :: Nx.Tensor.t()
-  def to_nx(%__MODULE__{type: :video} = frame) do
-    frame.data
-    |> Nx.from_binary(:u8)
-    |> Nx.reshape({frame.height, frame.width, 3})
-  end
+  if Code.ensure_loaded?(Nx) do
+    @doc """
+    Converts a frame to an Nx tensor.
+    """
+    @spec to_nx(t()) :: Nx.Tensor.t()
+    def to_nx(%__MODULE__{type: :video} = frame) do
+      frame.data
+      |> Nx.from_binary(:u8)
+      |> Nx.reshape({frame.height, frame.width, 3})
+    end
 
-  def to_nx(%__MODULE__{type: :audio} = frame) do
-    Nx.from_binary(frame.data, frame.format)
+    def to_nx(%__MODULE__{type: :audio} = frame) do
+      Nx.from_binary(frame.data, frame.format)
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -53,7 +53,7 @@ defmodule Xav.MixProject do
 
   defp deps do
     [
-      {:nx, "~> 0.7.0"},
+      {:nx, "~> 0.7.0", optional: true},
       {:elixir_make, "~> 0.7", runtime: false},
 
       # dev/test


### PR DESCRIPTION
Hey, really liking your library...i am using it currently to read metadata from video files, but i don't need the nx features. This is a proposal to make it optional, when user has the needed dependency like in the `image` library: https://github.com/elixir-image/image/blob/main/lib/image/nx.ex