### PR TITLE
Remove unused functions

### DIFF
--- a/c_src/xav/utils.c
+++ b/c_src/xav/utils.c
@@ -3,28 +3,6 @@
 #include <libavutil/opt.h>
 #include <stdint.h>
 
-void print_supported_pix_fmts(AVCodec *codec) {
-  if (codec->pix_fmts == NULL) {
-    fprintf(stdout, "unknown\n");
-  } else {
-    for (int i = 0; codec->pix_fmts[i] != -1; i++) {
-      fprintf(stdout, "fmt: %d\n", codec->pix_fmts[i]);
-    }
-  }
-}
-
-void convert_to_rgb(AVFrame *src_frame, uint8_t *dst_data[], int dst_linesize[]) {
-  struct SwsContext *sws_ctx =
-      sws_getContext(src_frame->width, src_frame->height, src_frame->format, src_frame->width,
-                     src_frame->height, AV_PIX_FMT_RGB24, SWS_BILINEAR, NULL, NULL, NULL);
-
-  av_image_alloc(dst_data, dst_linesize, src_frame->width, src_frame->height, AV_PIX_FMT_RGB24, 1);
-
-  // is this (const uint8_t * const*) cast really correct?
-  sws_scale(sws_ctx, (const uint8_t *const *)src_frame->data, src_frame->linesize, 0,
-            src_frame->height, dst_data, dst_linesize);
-}
-
 ERL_NIF_TERM xav_nif_ok(ErlNifEnv *env, ERL_NIF_TERM data_term) {
   ERL_NIF_TERM ok_term = enif_make_atom(env, "ok");
   return enif_make_tuple(env, 2, ok_term, data_term);

--- a/c_src/xav/utils.h
+++ b/c_src/xav/utils.h
@@ -3,7 +3,6 @@
 #include <libavdevice/avdevice.h>
 #include <libavformat/avformat.h>
 #include <libavutil/avutil.h>
-#include <libavutil/imgutils.h>
 #include <libswresample/swresample.h>
 #include <libswscale/swscale.h>
 
@@ -16,10 +15,6 @@
 
 #define XAV_ALLOC(X) enif_alloc(X)
 #define XAV_FREE(X) enif_free(X)
-
-void print_supported_pix_fmts(AVCodec *codec);
-void convert_to_rgb(AVFrame *src_frame, uint8_t *dst_data[], int dst_linesize[]);
-
 ERL_NIF_TERM xav_nif_ok(ErlNifEnv *env, ERL_NIF_TERM data_term);
 ERL_NIF_TERM xav_nif_error(ErlNifEnv *env, char *reason);
 ERL_NIF_TERM xav_nif_raise(ErlNifEnv *env, char *msg);

--- a/c_src/xav/video_converter.c
+++ b/c_src/xav/video_converter.c
@@ -1,5 +1,4 @@
 #include "video_converter.h"
-#include "utils.h"
 
 int video_converter_convert(AVFrame *src_frame, uint8_t *out_data[], int out_linesize[]) {
   int ret;

--- a/c_src/xav/video_converter.h
+++ b/c_src/xav/video_converter.h
@@ -1,5 +1,6 @@
 
 #include <libavutil/channel_layout.h>
+#include <libavutil/imgutils.h>
 #include <libswresample/swresample.h>
 #include <libswscale/swscale.h>
 #include <stdint.h>


### PR DESCRIPTION
I saw some warnings on my machine because FFmpeg 7.1 deprecated `codec->pix_fmts` (see https://github.com/FFmpeg/FFmpeg/blob/master/doc/APIchanges#L60)

```
c_src/xav/utils.c:7:14: warning: 'pix_fmts' is deprecated [-Wdeprecated-declarations]
    7 |   if (codec->pix_fmts == NULL) {
      |              ^
/opt/homebrew/Cellar/ffmpeg/7.1/include/libavcodec/codec.h:214:5: note: 'pix_fmts' has been explicitly marked deprecated here
  214 |     attribute_deprecated
      |     ^
/opt/homebrew/Cellar/ffmpeg/7.1/include/libavutil/attributes.h:100:49: note: expanded from macro 'attribute_deprecated'
  100 | #    define attribute_deprecated __attribute__((deprecated))
      |                                                 ^
c_src/xav/utils.c:10:28: warning: 'pix_fmts' is deprecated [-Wdeprecated-declarations]
   10 |     for (int i = 0; codec->pix_fmts[i] != -1; i++) {
      |                            ^
/opt/homebrew/Cellar/ffmpeg/7.1/include/libavcodec/codec.h:214:5: note: 'pix_fmts' has been explicitly marked deprecated here
  214 |     attribute_deprecated
      |     ^
/opt/homebrew/Cellar/ffmpeg/7.1/include/libavutil/attributes.h:100:49: note: expanded from macro 'attribute_deprecated'
  100 | #    define attribute_deprecated __attribute__((deprecated))
      |                                                 ^
c_src/xav/utils.c:11:43: warning: 'pix_fmts' is deprecated [-Wdeprecated-declarations]
   11 |       fprintf(stdout, "fmt: %d\n", codec->pix_fmts[i]);
      |                                           ^
/opt/homebrew/Cellar/ffmpeg/7.1/include/libavcodec/codec.h:214:5: note: 'pix_fmts' has been explicitly marked deprecated here
  214 |     attribute_deprecated
      |     ^
/opt/homebrew/Cellar/ffmpeg/7.1/include/libavutil/attributes.h:100:49: note: expanded from macro 'attribute_deprecated'
  100 | #    define attribute_deprecated __attribute__((deprecated))
      |                                                 ^
3 warnings generated.
Compiling 3 files (.ex)
Generated xav app
```

The functions aren't used anywhere so maybe we can just remove them for now?