### PR TITLE
Add :names to output tensor in to_nx/1

### DIFF
--- a/lib/frame.ex
+++ b/lib/frame.ex
@@ -71,7 +71,7 @@ defmodule Xav.Frame do
     def to_nx(%__MODULE__{type: :video} = frame) do
       frame.data
       |> Nx.from_binary(:u8)
-      |> Nx.reshape({frame.height, frame.width, 3})
+      |> Nx.reshape({frame.height, frame.width, 3}, names: [:height, :width, :channels])
     end
 
     def to_nx(%__MODULE__{type: :audio} = frame) do


### PR DESCRIPTION
When converting a frame to an `Nx.tensor/0` type, information regarding the axis order is lost. As a result, consuming applications, like [image](https://hex.pm/packages/image), are unable to determine whether the image is in column order (as expected by `Nx` and other typical vector libraries like [eVision](https://hex.pm/evision)), or in row order expected by typical image processing libraries such as `Image`.

By adding `:names` to the `Nx.reshape/2` call in `Xav.to_nx/1`, a consuming library can determine the in-memory order of the image data and act accordingly. As a result, integrating `image` and `xav` becomes a lot more straight forward.

PS: Thanks very much for making this library!