### PR TITLE
Make audio format consistent in decoder and reader

### DIFF
--- a/c_src/xav/xav_reader.c
+++ b/c_src/xav/xav_reader.c
@@ -228,22 +228,13 @@ static int init_audio_converter(struct XavReader *xav_reader) {
   }
 
   enum AVSampleFormat out_sample_fmt;
-  if (strcmp(xav_reader->out_format, "u8") == 0) {
-    out_sample_fmt = AV_SAMPLE_FMT_U8;
-  } else if (strcmp(xav_reader->out_format, "s16") == 0) {
-    out_sample_fmt = AV_SAMPLE_FMT_S16;
-  } else if (strcmp(xav_reader->out_format, "s32") == 0) {
-    out_sample_fmt = AV_SAMPLE_FMT_S32;
-  } else if (strcmp(xav_reader->out_format, "s64") == 0) {
-    out_sample_fmt = AV_SAMPLE_FMT_S64;
-  } else if (strcmp(xav_reader->out_format, "f32") == 0) {
-    out_sample_fmt = AV_SAMPLE_FMT_FLT;
-  } else if (strcmp(xav_reader->out_format, "f64") == 0) {
-    out_sample_fmt = AV_SAMPLE_FMT_DBL;
-  } else if (strcmp(xav_reader->out_format, "nil") == 0) {
+  if (strcmp(xav_reader->out_format, "nil") == 0) {
     out_sample_fmt = av_get_alt_sample_fmt(xav_reader->reader->c->sample_fmt, 0);
   } else {
-    return -1;
+    out_sample_fmt = av_get_sample_fmt(xav_reader->out_format);
+    if (out_sample_fmt == AV_SAMPLE_FMT_NONE) {
+      return -1;
+    }
   }
 
   struct ChannelLayout in_chlayout, out_chlayout;

--- a/lib/xav/decoder.ex
+++ b/lib/xav/decoder.ex
@@ -108,7 +108,6 @@ defmodule Xav.Decoder do
         :ok
 
       {:ok, {data, format, width, height, pts}} ->
-        format = normalize_format(format)
         {:ok, Xav.Frame.new(data, format, width, height, pts)}
 
       # Sometimes, audio converter might not return data immediately.
@@ -116,7 +115,6 @@ defmodule Xav.Decoder do
         :ok
 
       {:ok, {data, format, samples, pts}} ->
-        format = normalize_format(format)
         {:ok, Xav.Frame.new(data, format, samples, pts)}
 
       {:error, _reason} = error ->
@@ -151,9 +149,4 @@ defmodule Xav.Decoder do
       {:error, reason} -> raise "Failed to flush decoder: #{inspect(reason)}"
     end
   end
-
-  # Use the same formats as Nx
-  defp normalize_format(:flt), do: :f32
-  defp normalize_format(:dbl), do: :f64
-  defp normalize_format(other), do: other
 end

--- a/lib/xav/reader.ex
+++ b/lib/xav/reader.ex
@@ -3,8 +3,6 @@ defmodule Xav.Reader do
   Audio/video file reader.
   """
 
-  @audio_out_formats [:u8, :s16, :s32, :s64, :f32, :f64]
-
   @reader_options_schema [
     read: [
       type: {:in, [:audio, :video]},
@@ -17,10 +15,10 @@ defmodule Xav.Reader do
       doc: "Whether the path points to the camera"
     ],
     out_format: [
-      type: {:in, @audio_out_formats},
+      type: :atom,
       doc: """
-      The output format of the audio samples. It should be one of
-      the following values: `#{Enum.join(@audio_out_formats, ", ")}`.
+      The output format of the audio samples. For a list of available
+      sample formats check `Xav.sample_formats/0`.
 
       For video samples, it is always `:rgb24`.
       """

--- a/test/decoder_test.exs
+++ b/test/decoder_test.exs
@@ -307,7 +307,7 @@ defmodule Xav.DecoderTest do
     test "audio" do
       decoder = Xav.Decoder.new(:opus)
 
-      assert {:ok, %Xav.Frame{data: data, samples: 960, pts: 0, format: :f32}} =
+      assert {:ok, %Xav.Frame{data: data, samples: 960, pts: 0, format: :flt}} =
                Xav.Decoder.decode(decoder, @opus_frame)
 
       assert byte_size(data) == 7680

--- a/test/reader_test.exs
+++ b/test/reader_test.exs
@@ -126,7 +126,7 @@ defmodule Xav.ReaderTest do
       Xav.Reader.stream!(path,
         read: :audio,
         out_channels: 1,
-        out_format: :f32,
+        out_format: :flt,
         out_sample_rate: 16_000
       )
       |> Enum.map(&Xav.Frame.to_nx(&1))


### PR DESCRIPTION
I updated the audio sample format in reader to accept the `ffmpeg` naming too.