### PR TITLE
Get encoder by name

### DIFF
--- a/c_src/xav/encoder.c
+++ b/c_src/xav/encoder.c
@@ -16,10 +16,7 @@ struct Encoder *encoder_alloc() {
 }
 
 int encoder_init(struct Encoder *encoder, struct EncoderConfig *config) {
-  encoder->codec = avcodec_find_encoder(config->codec);
-  if (!encoder->codec) {
-    return -1;
-  }
+  encoder->codec = config->codec;
 
   encoder->c = avcodec_alloc_context3(encoder->codec);
   if (!encoder->c) {
@@ -44,7 +41,7 @@ int encoder_init(struct Encoder *encoder, struct EncoderConfig *config) {
   }
 
   AVDictionary *opts = NULL;
-  if (config->codec == AV_CODEC_ID_HEVC) {
+  if (strcmp(encoder->codec->name, "libx265") == 0) {
     char x265_params[256] = "log-level=warning";
     if (config->gop_size > 0) {
       sprintf(x265_params + strlen(x265_params), ":keyint=%d", config->gop_size);

--- a/c_src/xav/encoder.h
+++ b/c_src/xav/encoder.h
@@ -11,7 +11,7 @@ struct Encoder {
 
 struct EncoderConfig {
   enum AVMediaType media_type;
-  enum AVCodecID codec;
+  const AVCodec *codec;
   int width;
   int height;
   enum AVPixelFormat format;

--- a/c_src/xav/utils.c
+++ b/c_src/xav/utils.c
@@ -35,6 +35,20 @@ int xav_nif_get_atom(ErlNifEnv *env, ERL_NIF_TERM term, char **value) {
   return 1;
 }
 
+int xav_nif_get_string(ErlNifEnv *env, ERL_NIF_TERM term, char **value) {
+  ErlNifBinary bin;
+  if (!enif_inspect_binary(env, term, &bin)) {
+    return 0;
+  }
+
+  char *str_value = (char *)XAV_ALLOC((bin.size + 1) * sizeof(char *));
+  memcpy(str_value, bin.data, bin.size);
+  str_value[bin.size] = '\0';
+
+  *value = str_value;
+  return 1;
+}
+
 ERL_NIF_TERM xav_nif_audio_frame_to_term(ErlNifEnv *env, uint8_t **out_data, int out_samples,
                                          int out_size, enum AVSampleFormat out_format, int pts) {
   ERL_NIF_TERM data_term;

--- a/c_src/xav/utils.h
+++ b/c_src/xav/utils.h
@@ -21,6 +21,7 @@ ERL_NIF_TERM xav_nif_ok(ErlNifEnv *env, ERL_NIF_TERM data_term);
 ERL_NIF_TERM xav_nif_error(ErlNifEnv *env, char *reason);
 ERL_NIF_TERM xav_nif_raise(ErlNifEnv *env, char *msg);
 int xav_nif_get_atom(ErlNifEnv *env, ERL_NIF_TERM term, char **value);
+int xav_nif_get_string(ErlNifEnv *env, ERL_NIF_TERM term, char **value);
 ERL_NIF_TERM xav_nif_video_frame_to_term(ErlNifEnv *env, AVFrame *frame);
 ERL_NIF_TERM xav_nif_audio_frame_to_term(ErlNifEnv *env, uint8_t **out_data, int out_samples,
                                          int out_size, enum AVSampleFormat out_format, int pts);

--- a/c_src/xav/xav_decoder.c
+++ b/c_src/xav/xav_decoder.c
@@ -303,10 +303,13 @@ ERL_NIF_TERM list_decoders(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) 
   while ((codec = av_codec_iterate(&iter))) {
     if (av_codec_is_decoder(codec)) {
       ERL_NIF_TERM name = enif_make_atom(env, codec->name);
-      ERL_NIF_TERM long_name = enif_make_string(env, codec->long_name, ERL_NIF_LATIN1);
+      ERL_NIF_TERM codec_name = enif_make_atom(env, avcodec_get_name(codec->id));
+      ERL_NIF_TERM long_name = codec->long_name
+                                   ? enif_make_string(env, codec->long_name, ERL_NIF_LATIN1)
+                                   : enif_make_string(env, "", ERL_NIF_LATIN1);
       ERL_NIF_TERM media_type = enif_make_atom(env, av_get_media_type_string(codec->type));
 
-      ERL_NIF_TERM desc = enif_make_tuple3(env, name, long_name, media_type);
+      ERL_NIF_TERM desc = enif_make_tuple4(env, codec_name, name, long_name, media_type);
       result = enif_make_list_cell(env, desc, result);
     }
   }

--- a/lib/xav.ex
+++ b/lib/xav.ex
@@ -1,6 +1,21 @@
 defmodule Xav do
   @moduledoc File.read!("README.md")
 
+  @type encoder :: %{
+          codec: atom(),
+          name: atom(),
+          long_name: String.t(),
+          media_type: atom(),
+          profiles: [String.t()]
+        }
+
+  @type decoder :: %{
+          codec: atom(),
+          name: atom(),
+          long_name: String.t(),
+          media_type: atom()
+        }
+
   @doc """
   Get all available pixel formats.
 
@@ -24,17 +39,35 @@ defmodule Xav do
 
   @doc """
   List all decoders.
-
-  The result is a list of 3-element tuples `{name, long_name, media_type}`:
-    * `name` - The short name of the decoder.
-    * `long_name` - The long name of the decoder.
-    * `media_type` - The media type of the decoder.
   """
-  @spec list_decoders() :: [{name :: atom(), long_name :: String.t(), media_type :: atom()}]
+  @spec list_decoders() :: [decoder()]
   def list_decoders() do
     Xav.Decoder.NIF.list_decoders()
-    |> Enum.map(fn {name, long_name, media_type} ->
-      {name, List.to_string(long_name), media_type}
+    |> Enum.map(fn {codec, name, long_name, media_type} ->
+      %{
+        codec: codec,
+        name: name,
+        long_name: List.to_string(long_name),
+        media_type: media_type
+      }
+    end)
+    |> Enum.reverse()
+  end
+
+  @doc """
+  List all encoders.
+  """
+  @spec list_encoders() :: [encoder()]
+  def list_encoders() do
+    Xav.Encoder.NIF.list_encoders()
+    |> Enum.map(fn {family_name, name, long_name, media_type, _codec_id, profiles} ->
+      %{
+        codec: family_name,
+        name: name,
+        long_name: List.to_string(long_name),
+        media_type: media_type,
+        profiles: profiles |> Enum.map(&List.to_string/1) |> Enum.reverse()
+      }
     end)
     |> Enum.reverse()
   end

--- a/lib/xav/encoder_nif.ex
+++ b/lib/xav/encoder_nif.ex
@@ -13,4 +13,6 @@ defmodule Xav.Encoder.NIF do
   def encode(_encoder, _data, _pts), do: :erlang.nif_error(:undef)
 
   def flush(_encoder), do: :erlang.nif_error(:undef)
+
+  def list_encoders(), do: :erlang.nif_error(:undef)
 end

--- a/test/encoder_test.exs
+++ b/test/encoder_test.exs
@@ -17,7 +17,7 @@ defmodule Xav.EncoderTest do
     end
 
     test "raises on invalid encoder" do
-      assert_raise FunctionClauseError, fn -> Xav.Encoder.new(:h263, []) end
+      assert_raise ArgumentError, fn -> Xav.Encoder.new(:h264_none, []) end
     end
 
     test "raises on invalid options" do
@@ -109,7 +109,7 @@ defmodule Xav.EncoderTest do
         |> Enum.to_list()
 
       assert length(packets) == 20
-      Enum.all?(packets, &(&1.dts == &1.pts))
+      assert Enum.all?(packets, &(&1.dts == &1.pts)), "dts should be equal to pts"
     end
   end
 end


### PR DESCRIPTION
In this PR:

- Changed the `list_decoders/0` and `list_encoders` to return map. We'll include more information in this maps (currently added profiles field to encoders).
- `profile` is not an atom, it should be a binary. To get the available profiles, we should use `list_encoders/0`.
- We can use any encoder by using a name. (still only video encoders are supported, hardware encoders still needs more config, some of them may work directly without any extra config).