### PR TITLE
Fix cross compiling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ READER_SOURCES = $(XAV_DIR)/xav_reader.c $(XAV_DIR)/reader.c $(XAV_DIR)/video_co
 VIDEO_CONVERTER_HEADERS = $(XAV_DIR)/xav_video_converter.h $(XAV_DIR)/video_converter.h $(XAV_DIR)/utils.h
 VIDEO_CONVERTER_SOURCES = $(XAV_DIR)/xav_video_converter.c $(XAV_DIR)/video_converter.c $(XAV_DIR)/utils.c
 
-CFLAGS = $(XAV_DEBUG_LOGS) -fPIC -shared
+CFLAGS += $(XAV_DEBUG_LOGS) -fPIC -shared
 IFLAGS = -I$(ERTS_INCLUDE_DIR) -I$(XAV_DIR)
 LDFLAGS = -lavcodec -lswscale -lavutil -lavformat -lavdevice -lswresample
 

--- a/lib/xav/decoder_nif.ex
+++ b/lib/xav/decoder_nif.ex
@@ -1,6 +1,7 @@
 defmodule Xav.Decoder.NIF do
   @moduledoc false
 
+  @compile {:autoload, false}
   @on_load :__on_load__
 
   def __on_load__ do

--- a/lib/xav/encoder_nif.ex
+++ b/lib/xav/encoder_nif.ex
@@ -1,6 +1,7 @@
 defmodule Xav.Encoder.NIF do
   @moduledoc false
 
+  @compile {:autoload, false}
   @on_load :__on_load__
 
   def __on_load__ do

--- a/lib/xav/reader_nif.ex
+++ b/lib/xav/reader_nif.ex
@@ -1,6 +1,7 @@
 defmodule Xav.Reader.NIF do
   @moduledoc false
 
+  @compile {:autoload, false}
   @on_load :__on_load__
 
   def __on_load__ do

--- a/lib/xav/video_converter_nif.ex
+++ b/lib/xav/video_converter_nif.ex
@@ -1,6 +1,7 @@
 defmodule Xav.VideoConverter.NIF do
   @moduledoc false
 
+  @compile {:autoload, false}
   @on_load :__on_load__
 
   def __on_load__ do


### PR DESCRIPTION
Fixed cross compiling (`nerves`) and disabled auto loading of nifs after build.